### PR TITLE
Fix typos in comments

### DIFF
--- a/src/Moq/Moq.Sdk/Behavior.cs
+++ b/src/Moq/Moq.Sdk/Behavior.cs
@@ -28,7 +28,7 @@ namespace Moq.Sdk
         /// delegate and friendly display name.
         /// </summary>
         /// <remarks>
-        /// Use this constructor overload whenver constructing the display 
+        /// Use this constructor overload whenever constructing the display
         /// name is somewhat expensive.
         /// </remarks>
         public Behavior(InvokeBehavior invoke, Lazy<string> displayName)

--- a/src/Moq/Moq.Sdk/IMockFactory.cs
+++ b/src/Moq/Moq.Sdk/IMockFactory.cs
@@ -15,7 +15,7 @@ namespace Moq.Sdk
         /// <param name="baseType">The base type (or main interface) of the mock.</param>
         /// <param name="implementedInterfaces">Additional interfaces implemented by the mock, or an empty array.</param>
         /// <param name="construtorArguments">
-        /// Contructor arguments if the <paramref name="baseType" /> is a class, rather than an interface, or an empty array.
+        /// Constructor arguments if the <paramref name="baseType" /> is a class, rather than an interface, or an empty array.
         /// </param>
         /// <returns>A mock that implements <see cref="IMocked"/> in addition to the specified interfaces (if any).</returns>
 		object CreateMock(Assembly mocksAssembly, Type baseType, Type[] implementedInterfaces, object[] construtorArguments);

--- a/src/Moq/Moq.Sdk/MockContext.cs
+++ b/src/Moq/Moq.Sdk/MockContext.cs
@@ -17,7 +17,7 @@ namespace Moq.Sdk
         /// <summary>
         /// The last invocation on the mock, turned into an <see cref="IMockSetup"/> 
         /// ready for use together with the <see cref="IMock.BehaviorFor(IMockSetup)"/> 
-        /// method to locate the maching <see cref="IMockBehavior"/> to add new behaviors 
+        /// method to locate the matching <see cref="IMockBehavior"/> to add new behaviors
         /// when a matching invocation is performed.
         /// </summary>
         /// <remarks>

--- a/src/Moq/Moq/CallbackExtension.cs
+++ b/src/Moq/Moq/CallbackExtension.cs
@@ -23,7 +23,7 @@ namespace Moq
 
                 // If there is already a behavior wrap it instead, 
                 // so we can do a callback after even if it's a 
-                // shortcircuiting one like Returns.
+                // short-circuiting one like Returns.
                 if (behavior.Behaviors.Count > 0)
                 {
                     var wrapped = behavior.Behaviors.Pop();

--- a/src/Moq/Moq/ReturnsBehavior.cs
+++ b/src/Moq/Moq/ReturnsBehavior.cs
@@ -7,7 +7,7 @@ namespace Moq
 {
     /// <summary>
     /// A custom behavior for returning values, so that 
-    /// the actual value to return can be replaced on succesive 
+    /// the actual value to return can be replaced on successive
     /// <see cref="ReturnsExtension"/> method calls.
     /// </summary>
     [DebuggerDisplay("{DebuggerValue}", Name = "Returns", Type = nameof(ReturnsBehavior))]

--- a/src/Moq/Moq/ReturnsExtension.cs
+++ b/src/Moq/Moq/ReturnsExtension.cs
@@ -66,8 +66,8 @@ namespace Moq
             var setup = MockContext.CurrentSetup;
             if (setup != null)
             {
-                // TODO: Is this even necessary given that intellisense gives us 
-                // the rigth compiler safety already?
+                // TODO: Is this even necessary given that IntelliSense gives us
+                // the right compiler safety already?
                 setup.Invocation.EnsureCompatible(value);
 
                 var mock = ((IMocked)setup.Invocation.Target).Mock;

--- a/src/Stunts/Stunts.Analyzer/DiagnosticsExtensions.cs
+++ b/src/Stunts/Stunts.Analyzer/DiagnosticsExtensions.cs
@@ -21,7 +21,7 @@ namespace Stunts
         };
 
         /// <summary>
-        /// Gets the diangostics that represent build errors that happen when generated 
+        /// Gets the diagnostics that represent build errors that happen when generated
         /// code is out of date.
         /// </summary>
         public static Diagnostic[] GetCompilationErrors(this Compilation compilation) 

--- a/src/Stunts/Stunts.Analyzer/StuntGeneratorAnalyzer.cs
+++ b/src/Stunts/Stunts.Analyzer/StuntGeneratorAnalyzer.cs
@@ -50,12 +50,12 @@ namespace Stunts
         public virtual DiagnosticDescriptor OutdatedDiagnostic => StuntDiagnostics.OutdatedStunt;
 
         /// <summary>
-        /// Returns the single <see cref="MissingDiagnostic"/> this analyer supports.
+        /// Returns the single <see cref="MissingDiagnostic"/> this analyzer supports.
         /// </summary>
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
         {
             // NOTE: this creates the return value at this point because both Missing and Outdated 
-            // descriptors can be overriden as a customization point.
+            // descriptors can be overridden as a customization point.
             get { return ImmutableArray.Create(MissingDiagnostic, OutdatedDiagnostic); }
         }
 
@@ -74,7 +74,7 @@ namespace Stunts
             var generator = context.Compilation.GetTypeByMetadataName(generatorAttribute.FullName);
             if (generator == null)
                 // This may be an extender authoring error, but another analyzer should ensure proper 
-                // metadata references exist. Typically, the same nuget package that adds this analyzer 
+                // metadata references exist. Typically, the same NuGet package that adds this analyzer
                 // also adds the required assembly references, so this should never happen anyway.
                 return;
 

--- a/src/Stunts/Stunts.Analyzer/UnsupportedNestedTypeAnalyzer.cs
+++ b/src/Stunts/Stunts.Analyzer/UnsupportedNestedTypeAnalyzer.cs
@@ -12,7 +12,7 @@ namespace Stunts
     /// the <see cref="StuntGeneratorAttribute"/> and reports unsupported nested types for 
     /// codegen.
     /// </summary>
-    // TODO: this is a stop-gap meassure until we can figure out why the ImplementInterfaces codefix 
+    // TODO: this is a stop-gap measure until we can figure out why the ImplementInterfaces codefix
     // is not returning any code actions for the CSharpScaffold (maybe VB too?) when the type to 
     // be implemented is a nested interface :(. In the IDE, the code action is properly available after 
     // generating the (non-working, since the interface isn't implemented) mock class. 
@@ -58,7 +58,7 @@ namespace Stunts
         }
 
         /// <summary>
-        /// Returns the single descriptor this analyer supports.
+        /// Returns the single descriptor this analyzer supports.
         /// </summary>
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(descriptor);
 
@@ -77,7 +77,7 @@ namespace Stunts
             var generator = context.Compilation.GetTypeByMetadataName(generatorAttribute.FullName);
             if (generator == null)
                 // This may be an extender authoring error, but another analyzer should ensure proper 
-                // metadata references exist. Typically, the same nuget package that adds this analyzer 
+                // metadata references exist. Typically, the same NuGet package that adds this analyzer
                 // also adds the required assembly references, so this should never happen anyway.
                 return;
 

--- a/src/Stunts/Stunts.Analyzer/ValidateTypesAnalyzer.cs
+++ b/src/Stunts/Stunts.Analyzer/ValidateTypesAnalyzer.cs
@@ -33,7 +33,7 @@ namespace Stunts
 
         /// <summary>
         /// Returns the single <see cref="StuntDiagnostics.BaseTypeNotFirst"/> 
-        /// diagnostic this analyer supports.
+        /// diagnostic this analyzer supports.
         /// </summary>
         public sealed override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; }
             = ImmutableArray.Create(

--- a/src/Stunts/Stunts.Sdk/ProcessorPhase.cs
+++ b/src/Stunts/Stunts.Sdk/ProcessorPhase.cs
@@ -33,7 +33,7 @@
 
         /// <summary>
         /// Final phase that allows generators to perform additional generation beyond scaffold 
-        /// and inital stunt rewriting. Members generated in this phase are not rewritten at all 
+        /// and initial stunt rewriting. Members generated in this phase are not rewritten at all
         /// to use the <see cref="BehaviorPipeline"/> and can consist of language-specific fixups 
         /// or cleanups to make the generated code more idiomatic than the default code fixes may 
         /// provide.

--- a/src/Stunts/Stunts.Sdk/Processors/DefaultImports.cs
+++ b/src/Stunts/Stunts.Sdk/Processors/DefaultImports.cs
@@ -34,7 +34,7 @@ namespace Stunts.Processors
         public DefaultImports() : this(DefaultNamespaces) { }
 
         /// <summary>
-        /// Initializes the default imports a specific set of namespaces to add.
+        /// Initializes the default imports with a specific set of namespaces to add.
         /// </summary>
         public DefaultImports(params string[] namespaces) => this.namespaces = namespaces;
 

--- a/src/Stunts/Stunts.Sdk/Processors/SyntaxGeneratorExtensions.cs
+++ b/src/Stunts/Stunts.Sdk/Processors/SyntaxGeneratorExtensions.cs
@@ -7,7 +7,7 @@ using Microsoft.CodeAnalysis.Editing;
 namespace Stunts.Processors
 {
     /// <summary>
-    /// Language angnosti helper methods for code generation.
+    /// Language agnostic helper methods for code generation.
     /// </summary>
     static class SyntaxGeneratorExtensions
     {

--- a/src/Stunts/Stunts.Sdk/StuntGenerator.cs
+++ b/src/Stunts/Stunts.Sdk/StuntGenerator.cs
@@ -188,8 +188,8 @@ namespace Stunts
         public async Task<Document> ApplyProcessors(Document document, CancellationToken cancellationToken)
         {
 #if DEBUG
-            // While debugging the geneneration itself, don't let the cancellation timeouts 
-            // from tests to cause this to fail.
+            // While debugging the generation itself, don't let the cancellation timeouts
+            // from tests cause this to fail.
             if (Debugger.IsAttached)
                 cancellationToken = CancellationToken.None;
 #endif

--- a/src/Stunts/Stunts/BehaviorPipeline.cs
+++ b/src/Stunts/Stunts/BehaviorPipeline.cs
@@ -67,7 +67,7 @@ namespace Stunts
         /// <param name="invocation">Input to the method call.</param>
         /// <param name="target">The ultimate target of the call.</param>
         /// <param name="throwOnException">Whether to throw the <see cref="IMethodReturn.Exception"/> if it has a value after running 
-        /// the beaviors.</param>
+        /// the behaviors.</param>
         /// <returns>Return value from the pipeline.</returns>
         public IMethodReturn Invoke(IMethodInvocation invocation, InvokeBehavior target, bool throwOnException = false)
         {

--- a/src/Stunts/Stunts/IStuntFactory.cs
+++ b/src/Stunts/Stunts/IStuntFactory.cs
@@ -15,7 +15,7 @@ namespace Stunts
         /// <param name="baseType">The base type (or main interface) of the stunt.</param>
         /// <param name="implementedInterfaces">Additional interfaces implemented by the stunt, or an empty array.</param>
         /// <param name="construtorArguments">
-        /// Contructor arguments if the <paramref name="baseType" /> is a class, rather than an interface, or an empty array.
+        /// Constructor arguments if the <paramref name="baseType" /> is a class, rather than an interface, or an empty array.
         /// </param>
         /// <returns>A stunt that implements <see cref="IStunt"/> in addition to the specified interfaces (if any).</returns>
 		object CreateStunt(Assembly stuntsAssembly, Type baseType, Type[] implementedInterfaces, object[] construtorArguments);

--- a/src/Stunts/Stunts/StuntExtensions.cs
+++ b/src/Stunts/Stunts/StuntExtensions.cs
@@ -31,7 +31,7 @@ namespace Stunts
 		public static TStunt AddBehavior<TStunt>(this TStunt stunt, InvokeBehavior behavior, AppliesTo appliesTo = null, string name = null)
         {
             // We can't just add a constraint to the method signature, because 
-            // proxies are typically geneated and don't expose the IProxy interface directly.
+            // proxies are typically generated and don't expose the IProxy interface directly.
             if (stunt is IStunt target)
                 target.Behaviors.Add(StuntBehavior.Create(behavior, appliesTo, name));
             else
@@ -74,7 +74,7 @@ namespace Stunts
         }
 
         /// <summary>
-        /// Inserts a behavior into the stunt behasvior pipeline at the specified 
+        /// Inserts a behavior into the stunt behavior pipeline at the specified
         /// index.
         /// </summary>
         public static TStunt InsertBehavior<TStunt>(this TStunt stunt, int index, InvokeBehavior behavior, AppliesTo appliesTo = null, string name = null)
@@ -88,7 +88,7 @@ namespace Stunts
         }
 
         /// <summary>
-        /// Inserts a behavior into the stunt behasvior pipeline at the specified 
+        /// Inserts a behavior into the stunt behavior pipeline at the specified
         /// index.
         /// </summary>
         public static TStunt InsertBehavior<TStunt>(this TStunt stunt, int index, IStuntBehavior behavior)

--- a/src/build/Version.targets
+++ b/src/build/Version.targets
@@ -20,7 +20,7 @@ AssemblyVersion=$(AssemblyVersion)" />
   <!-- $(ExcludeRestorePackageImports)==true when invoking /t:Restore -->
   <Target Name="SetVersion" BeforeTargets="Build;GetPackageVersion;_IntrospectProjectProperties" DependsOnTargets="GitVersion" Condition="'$(ExcludeRestorePackageImports)' != 'true'">
     <PropertyGroup>
-      <!-- PR builds are *always* prerelease -->
+      <!-- PR builds are *always* pre-release -->
       <!-- TFS case: BUILD_REASON=PullRequest and BUILD_SOURCEBRANCH=refs/pull/#/merge -->
       <GitSemVerDashLabel Condition="'$(TF_BUILD)' == 'true' and '$(BUILD_REASON)' == 'PullRequest'">$(GitSemVerDashLabel)-pr$(BUILD_SOURCEBRANCH.Substring(10).TrimEnd('/merge'))</GitSemVerDashLabel>
       <GitSemVerDashLabel Condition="'$(APPVEYOR_PULL_REQUEST_NUMBER)' != ''">$(GitSemVerDashLabel)-pr$(APPVEYOR_PULL_REQUEST_NUMBER)</GitSemVerDashLabel>


### PR DESCRIPTION
I noticed a few typos in XML documentation comments and other code comments. Nothing major.