### PR TITLE
Add new ways of verifying mocks, with syntax and fluent APIs

### DIFF
--- a/src/Moq/Moq.Sdk.Tests/Fakes.cs
+++ b/src/Moq/Moq.Sdk.Tests/Fakes.cs
@@ -28,6 +28,10 @@ namespace Moq.Sdk.Tests
 
         public IArgumentMatcher[] Matchers { get; set; } = new IArgumentMatcher[0];
 
+        public Times? Occurrence { get; set; }
+
+        public StateBag State { get; } = new StateBag();
+
         IMethodInvocation IMockSetup.Invocation => Invocation;
 
         public bool Equals(IMockSetup other) => base.Equals(other);

--- a/src/Moq/Moq.Sdk.Tests/MockBehaviorTests.cs
+++ b/src/Moq/Moq.Sdk.Tests/MockBehaviorTests.cs
@@ -34,7 +34,7 @@ namespace Moq.Sdk.Tests
         [Fact]
         public void RecordsInvocation()
         {
-            var behavior = new MockTrackingBehavior();
+            var behavior = new MockRecordingBehavior();
             var mock = new Mocked();
 
             behavior.Execute(new MethodInvocation(mock, typeof(object).GetMethod(nameof(object.ToString))),
@@ -46,12 +46,12 @@ namespace Moq.Sdk.Tests
         [Fact]
         public void ThrowsForNonIMocked()
         {
-            var behavior = new MockTrackingBehavior();
+            var behavior = new MockRecordingBehavior();
 
             Assert.Throws<ArgumentException>(() => behavior.Execute(new MethodInvocation(
                 new object(),
                 typeof(Mocked).GetProperty(nameof(IMocked.Mock)).GetGetMethod()),
-                null));
+                () => (m, n) => m.CreateValueReturn(null)));
         }
 
         [Fact]

--- a/src/Moq/Moq.Sdk.Tests/MockTrackingBehaviorTests.cs
+++ b/src/Moq/Moq.Sdk.Tests/MockTrackingBehaviorTests.cs
@@ -13,7 +13,7 @@ namespace Moq.Sdk.Tests
         {
             var target = new TrackingMock();
             var invocation = new MethodInvocation(target, typeof(TrackingMock).GetMethod(nameof(TrackingMock.Do)));
-            var tracking = new MockTrackingBehavior();
+            var tracking = new MockContextBehavior();
 
             Assert.NotNull(tracking.Execute(invocation, () => (m, n) => m.CreateValueReturn(null)));
 
@@ -27,9 +27,9 @@ namespace Moq.Sdk.Tests
         {
             var target = new TrackingMock();
             var invocation = new MethodInvocation(target, typeof(TrackingMock).GetMethod(nameof(TrackingMock.Do)));
-            var tracking = new MockTrackingBehavior();
+            var recording = new MockRecordingBehavior();
 
-            Assert.NotNull(tracking.Execute(invocation, () => (m, n) => m.CreateValueReturn(null)));
+            Assert.NotNull(recording.Execute(invocation, () => (m, n) => m.CreateValueReturn(null)));
 
             Assert.Single(target.Mock.Invocations);
         }
@@ -39,7 +39,7 @@ namespace Moq.Sdk.Tests
         {
             var target = new TrackingMock();
             var invocation = new MethodInvocation(target, typeof(TrackingMock).GetMethod(nameof(TrackingMock.Do)));
-            var tracking = new MockTrackingBehavior();
+            var tracking = new MockContextBehavior();
 
             using (new SetupScope())
             {

--- a/src/Moq/Moq.Sdk.Tests/TimesFixture.cs
+++ b/src/Moq/Moq.Sdk.Tests/TimesFixture.cs
@@ -1,0 +1,215 @@
+﻿using System;
+using Xunit;
+
+namespace Moq.Sdk.Tests
+{
+    public class TimesFixture
+    {
+        [Theory]
+        [InlineData(0, false)]
+        [InlineData(1, true)]
+        [InlineData(int.MaxValue, true)]
+        public void DefaultTimesRangesBetweenOneAndMaxValue(int count, bool verifies)
+        {
+            Assert.Equal(verifies, default(Times).Validate(count));
+        }
+
+        [Fact]
+        public void AtLeastOnceRangesBetweenOneAndMaxValue()
+        {
+            var target = Times.AtLeastOnce;
+
+            Assert.False(target.Validate(-1));
+            Assert.False(target.Validate(0));
+            Assert.True(target.Validate(1));
+            Assert.True(target.Validate(5));
+            Assert.True(target.Validate(int.MaxValue));
+        }
+
+        [Fact]
+        public void AtLeastThrowsIfTimesLessThanOne()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => Times.AtLeast(0));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Times.AtLeast(-1));
+        }
+
+        [Fact]
+        public void AtLeastRangesBetweenTimesAndMaxValue()
+        {
+            var target = Times.AtLeast(10);
+
+            Assert.False(target.Validate(-1));
+            Assert.False(target.Validate(0));
+            Assert.False(target.Validate(9));
+            Assert.True(target.Validate(10));
+            Assert.True(target.Validate(int.MaxValue));
+        }
+
+        [Fact]
+        public void AtMostOnceRangesBetweenZeroAndOne()
+        {
+            var target = Times.AtMostOnce;
+
+            Assert.False(target.Validate(-1));
+            Assert.True(target.Validate(0));
+            Assert.True(target.Validate(1));
+            Assert.False(target.Validate(5));
+            Assert.False(target.Validate(int.MaxValue));
+        }
+
+        [Fact]
+        public void AtMostThrowsIfTimesLessThanZero()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => Times.AtMost(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Times.AtMost(-2));
+        }
+
+        [Fact]
+        public void AtMostRangesBetweenZeroAndTimes()
+        {
+            var target = Times.AtMost(10);
+
+            Assert.False(target.Validate(-1));
+            Assert.True(target.Validate(0));
+            Assert.True(target.Validate(6));
+            Assert.True(target.Validate(10));
+            Assert.False(target.Validate(11));
+            Assert.False(target.Validate(int.MaxValue));
+        }
+
+        [Fact]
+        public void ExactlyThrowsIfTimesLessThanZero()
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() => Times.Exactly(-1));
+            Assert.Throws<ArgumentOutOfRangeException>(() => Times.Exactly(-2));
+        }
+
+        [Fact]
+        public void ExactlyCheckExactTimes()
+        {
+            var target = Times.Exactly(10);
+
+            Assert.False(target.Validate(-1));
+            Assert.False(target.Validate(0));
+            Assert.False(target.Validate(9));
+            Assert.True(target.Validate(10));
+            Assert.False(target.Validate(11));
+            Assert.False(target.Validate(int.MaxValue));
+        }
+
+        [Fact]
+        public void NeverChecksZeroTimes()
+        {
+            var target = Times.Never;
+
+            Assert.False(target.Validate(-1));
+            Assert.True(target.Validate(0));
+            Assert.False(target.Validate(1));
+            Assert.False(target.Validate(int.MaxValue));
+        }
+
+        [Fact]
+        public void OnceChecksOneTime()
+        {
+            var target = Times.Once;
+
+            Assert.False(target.Validate(-1));
+            Assert.False(target.Validate(0));
+            Assert.True(target.Validate(1));
+            Assert.False(target.Validate(int.MaxValue));
+        }
+
+        public class Deconstruction
+        {
+            [Fact]
+            public void AtLeast_n_deconstructs_to_n_MaxValue()
+            {
+                const int n = 42;
+
+                var (from, to) = Times.AtLeast(n);
+                Assert.Equal(n, from);
+                Assert.Equal(int.MaxValue, to);
+            }
+
+            [Fact]
+            public void AtLeastOnce_deconstructs_to_1_MaxValue()
+            {
+                var (from, to) = Times.AtLeastOnce;
+                Assert.Equal(1, from);
+                Assert.Equal(int.MaxValue, to);
+            }
+
+            [Fact]
+            public void AtMost_n_deconstructs_to_0_n()
+            {
+                const int n = 42;
+
+                var (from, to) = Times.AtMost(n);
+                Assert.Equal(0, from);
+                Assert.Equal(n, to);
+            }
+
+            [Fact]
+            public void AtMostOnce_deconstructs_to_0_1()
+            {
+                var (from, to) = Times.AtMostOnce;
+                Assert.Equal(0, from);
+                Assert.Equal(1, to);
+            }
+
+            [Fact]
+            public void Exactly_n_deconstructs_to_n_n()
+            {
+                const int n = 42;
+                var (from, to) = Times.Exactly(n);
+                Assert.Equal(n, from);
+                Assert.Equal(n, to);
+            }
+
+            [Fact]
+            public void Once_deconstructs_to_1_1()
+            {
+                var (from, to) = Times.Once;
+                Assert.Equal(1, from);
+                Assert.Equal(1, to);
+            }
+
+            [Fact]
+            public void Never_deconstructs_to_0_0()
+            {
+                var (from, to) = Times.Never;
+                Assert.Equal(0, from);
+                Assert.Equal(0, to);
+            }
+        }
+
+        public class Equality
+        {
+#pragma warning disable xUnit2000 // Constants and literals should be the expected argument
+            [Fact]
+            public void default_Equals_AtLeastOnce()
+            {
+                Assert.Equal(Times.AtLeastOnce, default(Times));
+            }
+#pragma warning restore xUnit2000
+
+            [Fact]
+            public void default_GetHashCode_equals_AtLeastOnce_GetHashCode()
+            {
+                Assert.Equal(Times.AtLeastOnce.GetHashCode(), default(Times).GetHashCode());
+            }
+
+            [Fact]
+            public void Once_equals_Once()
+            {
+                Assert.Equal(Times.Once, Times.Once);
+            }
+
+            [Fact]
+            public void Once_equals_Exactly_1()
+            {
+                Assert.Equal(Times.Once, Times.Exactly(1));
+            }
+        }
+    }
+}

--- a/src/Moq/Moq.Sdk/IMock.cs
+++ b/src/Moq/Moq.Sdk/IMock.cs
@@ -27,7 +27,7 @@ namespace Moq.Sdk
         /// <summary>
         /// Arbitrary state associated with a mock instance.
         /// </summary>
-        MockState State { get; }
+        StateBag State { get; set; }
 
         /// <summary>
         /// The list of mock behavior pipelines configured for this mock.

--- a/src/Moq/Moq.Sdk/IMockSetup.cs
+++ b/src/Moq/Moq.Sdk/IMockSetup.cs
@@ -21,6 +21,17 @@ namespace Moq.Sdk
         IArgumentMatcher[] Matchers { get; }
 
         /// <summary>
+        /// Gets or sets an occurrence constraint placed on the setup, for matching 
+        /// or verification purposes.
+        /// </summary>
+        Times? Occurrence { get; set; }
+
+        /// <summary>
+        /// Arbitrary state associated with a setup.
+        /// </summary>
+        StateBag State { get; }
+
+        /// <summary>
         /// Tests whether the setup applies to an actual invocation.
         /// </summary>
         /// <param name="actualInvocation">An actual invocation performed on the mock.

--- a/src/Moq/Moq.Sdk/IMock`1.cs
+++ b/src/Moq/Moq.Sdk/IMock`1.cs
@@ -3,7 +3,7 @@
     /// <summary>
     /// Provides introspection information about a mock.
     /// </summary>
-    public interface IMock<T> : IMock, IFluentInterface
+    public interface IMock<out T> : IMock, IFluentInterface
     {
         /// <summary>
         /// The mock object this introspection data belongs to.

--- a/src/Moq/Moq.Sdk/MockContext.cs
+++ b/src/Moq/Moq.Sdk/MockContext.cs
@@ -10,7 +10,7 @@ namespace Moq.Sdk
     {
         /// <summary>
         /// The most recent invocation performed on the mock, tracked 
-        /// by the <see cref="MockTrackingBehavior"/>.
+        /// by the <see cref="MockContextBehavior"/>.
         /// </summary>
         public static IMethodInvocation CurrentInvocation
         {
@@ -26,7 +26,7 @@ namespace Moq.Sdk
         /// </summary>
         /// <remarks>
         /// This property is also tracked and populated by the 
-        /// <see cref="MockTrackingBehavior"/>.
+        /// <see cref="MockContextBehavior"/>.
         /// </remarks>
         public static IMockSetup CurrentSetup
         {

--- a/src/Moq/Moq.Sdk/MockContextBehavior.cs
+++ b/src/Moq/Moq.Sdk/MockContextBehavior.cs
@@ -1,19 +1,11 @@
 ﻿using System;
 using Stunts;
 using System.Diagnostics;
-using System.Linq;
-using System.Collections.Generic;
-using System.Reflection;
-using System.IO;
-using System.Runtime.Versioning;
-using System.Runtime.InteropServices;
-using System.Text;
 
 namespace Moq.Sdk
 {
     /// <summary>
-    /// Core behavior that allows tracking invocations and 
-    /// building setups from them. 
+    /// Core behavior that allows tracking invocations and building setups from them. 
     /// <para>
     /// Sets the <see cref="CallContext{IMethodInvocation}"/> 
     /// as well as the <see cref="CallContext{IMockSetup}"/>, used in 
@@ -21,7 +13,7 @@ namespace Moq.Sdk
     /// respectively.
     /// </para>
     /// </summary>
-    public class MockTrackingBehavior : IStuntBehavior
+    public class MockContextBehavior : IStuntBehavior
     {
         /// <summary>
         /// Returns <see langword="true"/> since it tracks all invocations.
@@ -42,10 +34,6 @@ namespace Moq.Sdk
             // Allows subsequent extension methods on the fluent API to retrieve the 
             // current setup being performed via the MockContext.
             MockContext.CurrentSetup = MockSetup.Freeze(invocation);
-
-            // Only record the invocation if it's *not* performed within a setup scope.
-            if (!SetupScope.IsActive)
-                invocation.Target.AsMock().Invocations.Add(invocation);
 
             // While debugging, capture invocation stack traces for easier 
             // troubleshooting

--- a/src/Moq/Moq.Sdk/MockDecorator.cs
+++ b/src/Moq/Moq.Sdk/MockDecorator.cs
@@ -30,7 +30,11 @@ namespace Moq.Sdk
         /// <summary>
         /// See <see cref="IMock.State"/>.
         /// </summary>
-        public virtual MockState State => mock.State;
+        public virtual StateBag State
+        {
+            get => mock.State;
+            set => mock.State = value;
+        }
 
         /// <summary>
         /// See <see cref="IMock.Setups"/>.

--- a/src/Moq/Moq.Sdk/MockRecordingBehavior.cs
+++ b/src/Moq/Moq.Sdk/MockRecordingBehavior.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Stunts;
+using System.Diagnostics;
+
+namespace Moq.Sdk
+{
+    /// <summary>
+    /// Records invocations performed on the mock, as long as 
+    /// <see cref="SetupScope.IsActive"/> is <see langword="false" />.
+    /// </summary>
+    public class MockRecordingBehavior : IStuntBehavior
+    {
+        /// <summary>
+        /// Returns <see langword="true"/> if <see cref="SetupScope.IsActive"/> is <see langword="false" />, 
+        /// since it will records all invocations in that case.
+        /// </summary>
+        public bool AppliesTo(IMethodInvocation invocation) => !SetupScope.IsActive;
+
+        /// <summary>
+        /// Implements the tracking of invocations for the excuted invocations.
+        /// </summary>
+        public IMethodReturn Execute(IMethodInvocation invocation, GetNextBehavior next)
+        {
+            invocation.Target.AsMock().Invocations.Add(invocation);
+
+            return next().Invoke(invocation, next);
+        }
+    }
+}

--- a/src/Moq/Moq.Sdk/MockSetup.cs
+++ b/src/Moq/Moq.Sdk/MockSetup.cs
@@ -37,6 +37,12 @@ namespace Moq.Sdk
         public IArgumentMatcher[] Matchers => matchers;
 
         /// <inheritdoc />
+        public Times? Occurrence { get; set; }
+
+        /// <inheritdoc />
+        public StateBag State { get; } = new StateBag();
+
+        /// <inheritdoc />
         public bool AppliesTo(IMethodInvocation actualInvocation)
         {
             if (actualInvocation == null)

--- a/src/Moq/Moq.Sdk/Properties/Resources.Designer.cs
+++ b/src/Moq/Moq.Sdk/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace Moq.Sdk.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {
@@ -61,11 +61,20 @@ namespace Moq.Sdk.Properties {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The mock already contains a tracking behavior..
+        ///   Looks up a localized string similar to The mock already contains a context behavior..
         /// </summary>
-        internal static string DuplicateTrackingBehavior {
+        internal static string DuplicateContextBehavior {
             get {
-                return ResourceManager.GetString("DuplicateTrackingBehavior", resourceCulture);
+                return ResourceManager.GetString("DuplicateContextBehavior", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The mock already contains a recording behavior..
+        /// </summary>
+        internal static string DuplicateRecordingBehavior {
+            get {
+                return ResourceManager.GetString("DuplicateRecordingBehavior", resourceCulture);
             }
         }
         

--- a/src/Moq/Moq.Sdk/Properties/Resources.resx
+++ b/src/Moq/Moq.Sdk/Properties/Resources.resx
@@ -126,7 +126,10 @@
   <data name="TargetNotMock" xml:space="preserve">
     <value>The target of the invocation is not a mock.</value>
   </data>
-  <data name="DuplicateTrackingBehavior" xml:space="preserve">
-    <value>The mock already contains a tracking behavior.</value>
+  <data name="DuplicateContextBehavior" xml:space="preserve">
+    <value>The mock already contains a context behavior.</value>
+  </data>
+  <data name="DuplicateRecordingBehavior" xml:space="preserve">
+    <value>The mock already contains a recording behavior.</value>
   </data>
 </root>

--- a/src/Moq/Moq.Sdk/StateBag.cs
+++ b/src/Moq/Moq.Sdk/StateBag.cs
@@ -7,11 +7,26 @@ namespace Moq.Sdk
     /// <summary>
     /// A typed state bag for holding arbitrary mock state. All members are thread-safe.
     /// </summary>
-    [DebuggerDisplay("Count = {state.Count}", Name = "State", Type = nameof(MockState))]
-    public class MockState
+    [DebuggerDisplay("Count = {state.Count}", Name = "State", Type = nameof(StateBag))]
+    public class StateBag
     {
         [DebuggerBrowsable(DebuggerBrowsableState.RootHidden)]
-        ConcurrentDictionary<object, object> state = new ConcurrentDictionary<object, object>();
+        ConcurrentDictionary<object, object> state;
+
+        /// <summary>
+        /// Creates a new instance of the state bag.
+        /// </summary>
+        public StateBag()
+            : this(new ConcurrentDictionary<object, object>())
+        {
+        }
+
+        private StateBag(ConcurrentDictionary<object, object> initialState) => state = new ConcurrentDictionary<object, object>(initialState);
+
+        /// <summary>
+        /// Creates a copy of the state bag.
+        /// </summary>
+        public StateBag Clone() => new StateBag(state);
 
         /// <summary>
         /// Clears the state.
@@ -95,7 +110,10 @@ namespace Moq.Sdk
         public bool TryGetValue<T>(out T value)
         {
             var result = state.TryGetValue(typeof(T), out var _value);
-            value = (T)_value;
+            value = default;
+            if (result && _value != null)
+                value = (T)_value;
+
             return result;
         }
 
@@ -111,7 +129,10 @@ namespace Moq.Sdk
         public bool TryGetValue<T>(object key, out T value)
         {
             var result = state.TryGetValue(Key<T>(key), out var _value);
-            value = (T)_value;
+            value = default;
+            if (result && _value != null)
+                value = (T)_value;
+
             return result;
         }
 
@@ -126,7 +147,10 @@ namespace Moq.Sdk
         public bool TryRemove<T>(out T value)
         {
             var result = state.TryRemove(typeof(T), out var _value);
-            value = (T)_value;
+            value = default;
+            if (result && _value != null)
+                value = (T)_value;
+
             return result;
         }
 
@@ -142,7 +166,10 @@ namespace Moq.Sdk
         public bool TryRemove<T>(object key, out T value)
         {
             var result = state.TryRemove(Key<T>(key), out var _value);
-            value = (T)_value;
+            value = default;
+            if (result && _value != null)
+                value = (T)_value;
+
             return result;
         }
 
@@ -178,6 +205,6 @@ namespace Moq.Sdk
         /// <summary>
         /// Gets the key to use depending on the received <typeparamref name="T"/>.
         /// </summary>
-        object Key<T>(object key) => typeof(T) == typeof(object) ? key : Tuple.Create(typeof(T), key);
+        object Key<T>(object key) => typeof(T) == typeof(object) ? key : (Key: key, Type: typeof(T));
     }
 }

--- a/src/Moq/Moq.Sdk/Times.cs
+++ b/src/Moq/Moq.Sdk/Times.cs
@@ -1,0 +1,219 @@
+﻿using System;
+using System.ComponentModel;
+using Stunts;
+
+namespace Moq.Sdk
+{
+    /// <summary>
+    /// Defines the number of expected invocations.
+    /// </summary>
+    public readonly struct Times : IEquatable<Times>
+    {
+        readonly Lazy<int> hashCode;
+
+        /// <summary>
+        /// Initializes the constraint with the given <paramref name="from"/> and 
+        /// <paramref name="to"/> values.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public Times(int from, int to)
+        {
+            From = from;
+            To = to;
+            hashCode = new Lazy<int>(() => new HashCode().AddRange(from, to).ToHashCode());
+        }
+
+        /// <summary>
+        /// At least one call is expected.
+        /// </summary>
+        public static Times AtLeastOnce { get; } = new Times(1, int.MaxValue);
+
+        /// <summary>
+        /// At most one call is expected.
+        /// </summary>
+        public static Times AtMostOnce { get; } = new Times(0, 1);
+
+        /// <summary>
+        /// No calls are expected.
+        /// </summary>
+        public static Times Never { get; } = new Times(0, 0);
+
+        /// <summary>
+        /// Exactly one call is expected.
+        /// </summary>
+        public static Times Once { get; } = new Times(1, 1);
+
+        /// <summary>
+        /// The minimum calls expected.
+        /// </summary>
+        public int From { get; }
+
+        /// <summary>
+        /// The maximum calls expected.
+        /// </summary>
+        public int To { get; }
+
+        /// <summary>Deconstructs this instance.</summary>
+        /// <param name="from">This output parameter will receive the minimum required number of calls satisfying this instance (i.e. the lower inclusive bound).</param>
+        /// <param name="to">This output parameter will receive the maximum allowed number of calls satisfying this instance (i.e. the upper inclusive bound).</param>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public void Deconstruct(out int from, out int to)
+        {
+            if (hashCode == null)
+            {
+                // default(Times) == AtLeastOnce
+                AtLeastOnce.Deconstruct(out from, out to);
+            }
+            else
+            {
+                from = From;
+                to = To;
+            }
+        }
+
+        /// <summary>
+        /// At least <paramref name="count"/> calls are expected.
+        /// </summary>
+        /// <param name="count">The minimum number of expected calls.</param>
+        public static Times AtLeast(int count)
+        {
+            if (count < 1)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            return new Times(count, int.MaxValue);
+        }
+
+        /// <summary>
+        /// At most <paramref name="count"/> calls are expected.
+        /// </summary>
+        /// <param name="count">The maximum number of expected calls.</param>
+        public static Times AtMost(int count)
+        {
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            return new Times(0, count);
+        }
+
+        /// <summary>
+        /// Exactly <paramref name="count"/> call is expected.
+        /// </summary>
+        /// <param name="count">The times that a method or property can be called.</param>
+        public static Times Exactly(int count)
+        {
+            if (count < 0)
+                throw new ArgumentOutOfRangeException(nameof(count));
+
+            return new Times(count, count);
+        }
+
+        /// <summary>
+        /// Validates whether the given <paramref name="count"/> value satisfies this 
+        /// occurrence constraint.
+        /// </summary>
+        /// <param name="count">The number of calls to validate against this occurrence constraint.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="count"/> is included in the range <see cref="From"/>-<see cref="To"/>
+        /// (inclusive).
+        /// </returns>
+        public bool Validate(int count)
+        {
+            // By deconstructing, we apply our default behavior of considering default(Times) == AtLeastOnce.
+            var (from, to) = this;
+            return count >= from && count <= to;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified <see cref="Times"/> value.
+        /// </summary>
+        /// <param name="other">A <see cref="Times"/> value to compare to this instance.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="other"/> has the same value as this instance;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>
+        public bool Equals(Times other)
+        {
+            // By deconstructing first, we apply the behavior for default(Times) == AtLeastOnce
+            var (from, to) = this;
+            var (otherFrom, otherTo) = other;
+
+            return from == otherFrom && to == otherTo;
+        }
+
+        /// <summary>
+        /// Returns a value indicating whether this instance is equal to a specified <see cref="Times"/> value.
+        /// </summary>
+        /// <param name="obj">An object to compare to this instance.</param>
+        /// <returns>
+        /// <see langword="true"/> if <paramref name="obj"/> has the same value as this instance;
+        /// otherwise, <see langword="false"/>.
+        /// </returns>s
+        public override bool Equals(object obj) => obj is Times other && Equals(other);
+
+        /// <summary>
+        ///   Returns a hash code for this instance.
+        /// </summary>
+        /// <returns>
+        ///  A hash code for this instance, suitable for use in hashing algorithms
+        ///  and data structures like a hash table.
+        /// </returns>
+        public override int GetHashCode() => hashCode == null ? AtLeastOnce.GetHashCode() : hashCode.Value;
+
+        /// <summary>
+        ///   Determines whether two specified <see cref="Times"/> objects have the same value.
+        /// </summary>
+        /// <param name="left">The first <see cref="Times"/>.</param>
+        /// <param name="right">The second <see cref="Times"/>.</param>
+        /// <returns>
+        ///   <see langword="true"/> if <paramref name="left"/> has the same value as <paramref name="right"/>;
+        ///   otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator ==(Times left, Times right) => left.Equals(right);
+
+        /// <summary>
+        ///   Determines whether two specified <see cref="Times"/> objects have different values.
+        /// </summary>
+        /// <param name="left">The first <see cref="Times"/>.</param>
+        /// <param name="right">The second <see cref="Times"/>.</param>
+        /// <returns>
+        ///   <see langword="true"/> if the value of <paramref name="left"/> is different from
+        ///   <paramref name="right"/>'s; otherwise, <see langword="false"/>.
+        /// </returns>
+        public static bool operator !=(Times left, Times right) => !left.Equals(right);
+
+        /// <summary>
+        /// Converts an integer to <see cref="AtLeastOnce"/> if <paramref name="count"/> is <c>-1</c>, 
+        /// <see cref="Never"/> if <paramref name="count"/> is <c>0</c>, 
+        /// <see cref="Once"/> if <paramref name="count"/> is <c>1</c> and 
+        /// <see cref="Exactly(int)"/> with <paramref name="count"/> otherwise.
+        /// </summary>
+        public static implicit operator Times(int count) => count switch
+        {
+            -1 => AtLeastOnce,
+            0 => Never,
+            1 => Once, 
+            _ => Exactly(count)
+        };
+
+        /// <summary>
+        /// Provide a friendly representation of the expected range.
+        /// </summary>
+        public override string ToString()
+        {
+            if (this == Once)
+                return nameof(Once);
+            if (this == Never)
+                return nameof(Never);
+            if (this == AtLeastOnce)
+                return nameof(AtLeastOnce);
+            if (this == AtMostOnce)
+                return nameof(AtMostOnce);
+            if (From == 0 && To != 0)
+                return $"{nameof(AtMost)}({To})";
+            if (From != 0 && To == int.MaxValue)
+                return $"{nameof(AtLeast)}({From})";
+
+            return $"{From}..{To}";
+        }
+    }
+}

--- a/src/Moq/Moq.Tests/DynamicMockTests.cs
+++ b/src/Moq/Moq.Tests/DynamicMockTests.cs
@@ -12,7 +12,7 @@ namespace Moq.Sdk.Tests
         public async Task WhenAddingMockBehavior_ThenCanInterceptSelectively()
         {
             var calculator = await new DynamicMock(LanguageNames.CSharp).CreateAsync<ICalculator>();
-            var behavior = new MockTrackingBehavior();
+            var behavior = new MockContextBehavior();
 
             calculator.AddBehavior(behavior);
             calculator.AddBehavior((m, n) => m.CreateValueReturn(CalculatorMode.Scientific), m => m.MethodBase.Name == "get_Mode");

--- a/src/Moq/Moq.Tests/MoqTests.cs
+++ b/src/Moq/Moq.Tests/MoqTests.cs
@@ -5,11 +5,17 @@ using Moq.Sdk;
 using static Moq.Syntax;
 using Stunts;
 using Sample;
+using System.Linq;
+using Xunit.Abstractions;
 
 namespace Moq.Tests
 {
     public class MoqTests
     {
+        ITestOutputHelper output;
+
+        public MoqTests(ITestOutputHelper output) => this.output = output;
+
         [Fact]
         public void CanRaiseEvents()
         {

--- a/src/Moq/Moq.Tests/VerificationTests.cs
+++ b/src/Moq/Moq.Tests/VerificationTests.cs
@@ -1,0 +1,325 @@
+﻿using System;
+using Moq.Sdk;
+using Sample;
+using Xunit;
+using Xunit.Abstractions;
+using static Moq.Syntax;
+
+namespace Moq.Tests
+{
+    public class VerificationTests
+    {
+        readonly ITestOutputHelper output;
+
+        public VerificationTests(ITestOutputHelper output) => this.output = output;
+
+        [Fact]
+        public void VerifySyntaxOnceOnSetup()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            calculator.Add(2, 3).Returns(5).Once();
+
+            Assert.ThrowsAny<VerifyException>(() => Verify(calculator));
+            
+            calculator.Add(2, 3);
+
+            // TODO: We should have a this.Verify() extension method for backs compat.
+            Verify(calculator);
+
+            calculator.Add(2, 3);
+
+            Assert.ThrowsAny<VerifyException>(() => Verify(calculator));
+        }
+
+        [Fact]
+        public void VerifySyntaxOnceOnVerify()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            Assert.Throws<VerifyException>(() => Verify(calculator).Add(2, 3).Once());
+
+            calculator.Add(2, 3);
+
+            Verify(calculator).Add(2, 3).Once();
+
+            calculator.Add(2, 3);
+
+            Assert.Throws<VerifyException>(() => Verify(calculator).Add(2, 3).Once());
+        }
+
+        [Fact]
+        public void VerifySyntaxNeverOnSetup()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            calculator.Add(2, 3).Returns(5).Never();
+
+            Verify(calculator);
+
+            calculator.Add(2, 3);
+
+            Assert.Throws<VerifyException>(() => Verify(calculator));
+        }
+
+        [Fact]
+        public void VerifySyntaxNeverOnVerify()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            calculator.Add(2, 3).Returns(5);
+
+            Verify(calculator).Add(2, 3).Never();
+
+            calculator.Add(2, 3);
+
+            Assert.Throws<VerifyException>(() => Verify(calculator).Add(2, 3).Never());
+        }
+
+        [Fact]
+        public void VerifySyntaxExactlyOnSetup()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            calculator.Add(2, 3).Returns(5).Exactly(2);
+            calculator.Add(2, 3);
+
+            Assert.Throws<VerifyException>(() => Verify(calculator));
+
+            calculator.Add(2, 3);
+
+            Verify(calculator);
+
+            calculator.Add(2, 3);
+
+            Assert.Throws<VerifyException>(() => Verify(calculator));
+        }
+
+        [Fact]
+        public void VerifySyntaxExactlyOnVerify()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            calculator.Add(2, 3).Returns(5);
+            calculator.Add(2, 3);
+
+            Assert.Throws<VerifyException>(() => Verify(calculator).Add(2, 3).Exactly(2));
+
+            calculator.Add(2, 3);
+
+            Verify(calculator).Add(2, 3).Exactly(2);
+
+            calculator.Add(2, 3);
+
+            Assert.Throws<VerifyException>(() => Verify(calculator).Add(2, 3).Never());
+        }
+
+        [Fact]
+        public void VerifyPropertySet()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            Assert.Throws<VerifyException>(() => Verify.Called(() => calculator.Mode = CalculatorMode.Scientific));
+
+            calculator.Mode = CalculatorMode.Scientific;
+
+            Verify.Called(() => calculator.Mode = CalculatorMode.Scientific);
+        }
+
+        [Fact]
+        public void VerifyVoidMethod()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            Assert.Throws<VerifyException>(() => Verify.Called(() => calculator.TurnOn()));
+
+            calculator.TurnOn();
+
+            Verify.Called(() => calculator.TurnOn());
+
+            Assert.Throws<VerifyException>(() => Verify.Called(() => calculator.TurnOn(), 2));
+
+            calculator.TurnOn();
+
+            Verify.Called(() => calculator.TurnOn(), 2);
+        }
+
+        [Fact]
+        public void VerifyNotCalled()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            Verify.NotCalled(() => calculator.TurnOn());
+            Verify.NotCalled(() => calculator.Add(2, 3));
+
+            calculator.TurnOn();
+            calculator.Add(2, 3);
+
+            Assert.Throws<VerifyException>(() => Verify.NotCalled(() => calculator.TurnOn()));
+            Assert.Throws<VerifyException>(() => Verify.NotCalled(() => calculator.Add(2, 3)));
+        }
+
+        [Fact]
+        public void VerifyNotCalledFluent()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            Verify.NotCalled(calculator).TurnOn();
+            Verify.NotCalled(calculator).Add(2, 3);
+
+            calculator.TurnOn();
+            calculator.Add(2, 3);
+
+            Assert.Throws<VerifyException>(() => Verify.NotCalled(calculator).TurnOn());
+            Assert.Throws<VerifyException>(() => Verify.NotCalled(calculator).Add(2, 3));
+        }
+
+        [Fact]
+        public void VerifyCalls()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            calculator.Setup(c => c.TurnOn()).Once();
+            calculator.Add(2, 3).Returns(5).Once();
+
+            Assert.Throws<VerifyException>(() => Verify.Calls(calculator));
+
+            calculator.TurnOn();
+            calculator.Add(2, 3);
+
+            Verify.Calls(calculator);
+        }
+
+        [Fact]
+        public void VerifyCallsCustom()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            calculator.Setup(c => c.TurnOn()).Once();
+            calculator.Add(2, 3).Returns(5).Once();
+
+            Verify.Calls(
+                () => calculator.TurnOn(),
+                calls => Assert.Empty(calls));
+
+            calculator.TurnOn();
+
+            Verify.Calls(
+                () => calculator.TurnOn(),
+                calls => Assert.Single(calls));
+        }
+
+        [Fact]
+        public void VerifyExtensionAction()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            // At least once
+            Assert.Throws<VerifyException>(() => calculator.Verify(x => x.TurnOn()));
+            // Once
+            Assert.Throws<VerifyException>(() => calculator.Verify(x => x.TurnOn(), 1));
+            // At least once with message
+            Assert.Throws<VerifyException>(() => calculator.Verify(x => x.TurnOn(), "Should have been called!"));
+            // Once with message
+            Assert.Throws<VerifyException>(() => calculator.Verify(x => x.TurnOn(), 1, "Should have been called!"));
+            // Times.Once with message
+            Assert.Throws<VerifyException>(() => calculator.Verify(x => x.TurnOn(), Times.Once, "Should have been called!"));
+
+            calculator.TurnOn();
+
+            // At least once
+            calculator.Verify(x => x.TurnOn());
+            // Once
+            calculator.Verify(x => x.TurnOn(), 1);
+            // At least once with message
+            calculator.Verify(x => x.TurnOn(), "Should have been called!");
+            // Once with message
+            calculator.Verify(x => x.TurnOn(), 1, "Should have been called!");
+            // Times.Once with message
+            calculator.Verify(x => x.TurnOn(), Times.Once, "Should have been called!");
+        }
+
+        [Fact]
+        public void VerifyExtensionFunction()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            // At least once
+            Assert.Throws<VerifyException>(() => calculator.Verify(x => x.Add(2, 3)));
+            // Once
+            Assert.Throws<VerifyException>(() => calculator.Verify(x => x.Add(2, 3), 1));
+            // At least once with message
+            Assert.Throws<VerifyException>(() => calculator.Verify(x => x.Add(2, 3), "Should have been called!"));
+            // Once with message
+            Assert.Throws<VerifyException>(() => calculator.Verify(x => x.Add(2, 3), 1, "Should have been called!"));
+            // Times.Once with message
+            Assert.Throws<VerifyException>(() => calculator.Verify(x => x.Add(2, 3), Times.Once, "Should have been called!"));
+
+            calculator.Add(2, 3);
+
+            // At least once
+            calculator.Verify(x => x.Add(2, 3));
+            // Once
+            calculator.Verify(x => x.Add(2, 3), 1);
+            // At least once with message
+            calculator.Verify(x => x.Add(2, 3), "Should have been called!");
+            // Once with message
+            calculator.Verify(x => x.Add(2, 3), 1, "Should have been called!");
+            // Times.Once with message
+            calculator.Verify(x => x.Add(2, 3), Times.Once, "Should have been called!");
+        }
+
+        //[Fact]
+        public void CanVerify()
+        {
+            var calculator = Mock.Of<ICalculator>();
+
+            calculator.Add(2, 3).Returns(5).Once();
+            calculator.Mode.Returns(CalculatorMode.Scientific).Exactly(2);
+
+            var mock = Mock.Get(calculator);
+            foreach (var invocation in mock.Invocations)
+            {
+                output.WriteLine((string)invocation.Context[nameof(Environment.StackTrace)]);
+            }
+
+            // Syntax-based, follows straightforward setup approach, no lambdas.
+            Verify(calculator).Mode = CalculatorMode.Scientific;
+            Verify(calculator).Add(2, 3);
+            
+            // Verify all "verifiable" calls, i.e. those with 
+            // a Once/Never/etc. setup.
+            Verify(calculator);
+            // Long form, with no lambda
+            Verify.Called(calculator);
+
+            // equivalent non-syntax version
+            //calculator.Verify().Add(2, 3);
+            Verify(calculator).Add(1, 1).Never();
+
+            // Explicit Verify, still no lambdas, long form of Syntax
+            Verify.Called(calculator).Add(2, 3).Exactly(2);
+            // Explicit Verify, still no lambdas, long form of Syntax
+            Verify.NotCalled(calculator).Add(2, 3);
+
+            // For the case where you want keep the mock in "running" mode after the verify. 
+
+            Verify.Called(() => calculator.Add(2, 3).Once());
+            Verify.NotCalled(() => calculator.TurnOn());
+
+            // More advanced verification, access calls via lambda
+            Verify.Calls(
+                () => calculator.Add(2, 3),
+                calls => Assert.Single(calls));
+            // Works for void/action
+            Verify.Calls(
+                () => calculator.TurnOn(),
+                calls => Assert.Single(calls));
+
+            // Verify all "verifiable" calls, i.e. those with 
+            // a Once/Never/etc. setup.
+            Verify.Calls(calculator);
+            // calculator.Verify();
+        }
+    }
+}

--- a/src/Moq/Moq/MockInitializer.cs
+++ b/src/Moq/Moq/MockInitializer.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.ComponentModel;
-using System.Diagnostics;
+﻿using System.ComponentModel;
 using System.Linq;
-using Moq.Properties;
 using Moq.Sdk;
 using Stunts;
 
@@ -10,7 +7,7 @@ namespace Moq
 {
     /// <summary>
     /// Provides the <see cref="Initialize"/> method for configuring the initial 
-    /// behaviors set of behaviors for a given <see cref="MockBehavior"/>.
+    /// set of behaviors for a given <see cref="MockBehavior"/>.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class MockInitializer
@@ -29,7 +26,8 @@ namespace Moq
         {
             mocked.Mock.Behaviors.Clear();
 
-            mocked.Mock.Behaviors.Add(new MockTrackingBehavior());
+            mocked.Mock.Behaviors.Add(new MockContextBehavior());
+            mocked.Mock.Behaviors.Add(new MockRecordingBehavior());
             mocked.Mock.Behaviors.Add(new EventBehavior());
             mocked.Mock.Behaviors.Add(new PropertyBehavior { SetterRequiresSetup = behavior == MockBehavior.Strict });
             mocked.Mock.Behaviors.Add(new DefaultEqualityBehavior());

--- a/src/Moq/Moq/Moq.csproj
+++ b/src/Moq/Moq/Moq.csproj
@@ -21,6 +21,14 @@
   </ItemGroup>
 
   <ItemGroup>
+    <Compile Remove="Legacy\Mock`1.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="Legacy\Mock`1.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>
       <AutoGen>True</AutoGen>

--- a/src/Moq/Moq/OccurrenceExtension.cs
+++ b/src/Moq/Moq/OccurrenceExtension.cs
@@ -1,0 +1,122 @@
+﻿using System.ComponentModel;
+using System.Linq;
+using Moq.Sdk;
+
+namespace Moq
+{
+    /// <summary>
+    /// Extensions for specifying occurrence for behavior specification 
+    /// or verification.
+    /// </summary>
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public static class OccurrenceExtension
+    {
+        /// <summary>
+        /// Supports legacy API and forwards to <see cref="AtLeastOnce{TResult}(TResult)"/>.
+        /// </summary>
+        [EditorBrowsable(EditorBrowsableState.Never)]
+        public static TResult Verifiable<TResult>(this TResult target) => AtLeastOnce(target);
+
+        /// <summary>
+        /// Specifies that the current fluent invocation is expected to be 
+        /// called at least once.
+        /// </summary>
+        public static TResult AtLeastOnce<TResult>(this TResult target)
+        {
+            var setup = MockContext.CurrentSetup;
+            if (setup != null)
+            {
+                setup.Occurrence = Times.AtLeastOnce;
+                var mock = setup.Invocation.Target.AsMock();
+                if (Verify.IsVerifying(mock))
+                {
+                    var calls = mock.Invocations.Where(call => setup.AppliesTo(call));
+                    if (!calls.Any())
+                        throw new VerifyException(mock, setup);
+                }
+            }
+            else
+            {
+                // TODO: throw if no setup?
+            }
+
+            return default;
+        }
+
+        /// <summary>
+        /// Specifies that the current fluent invocation is expected to be 
+        /// called exactly once.
+        /// </summary>
+        public static TResult Once<TResult>(this TResult target)
+        {
+            var setup = MockContext.CurrentSetup;
+            if (setup != null)
+            {
+                setup.Occurrence = Times.Once;
+                var mock = setup.Invocation.Target.AsMock();
+                if (Verify.IsVerifying(mock))
+                {
+                    var calls = mock.Invocations.Where(call => setup.AppliesTo(call)).Take(2).ToArray();
+                    if (calls.Length != 1)
+                        throw new VerifyException(mock, setup);
+                }
+            }
+            else
+            {
+                // TODO: throw if no setup?
+            }
+
+            return default;
+        }
+
+        /// <summary>
+        /// Specifies that the current fluent invocation is expected to never 
+        /// be called.
+        /// </summary>
+        public static TResult Never<TResult>(this TResult target)
+        {
+            var setup = MockContext.CurrentSetup;
+            if (setup != null)
+            {
+                setup.Occurrence = Times.Never;
+                var mock = setup.Invocation.Target.AsMock();
+                if (Verify.IsVerifying(mock))
+                {
+                    if (mock.Invocations.Where(call => setup.AppliesTo(call)).Any())
+                        throw new VerifyException(mock, setup);
+                }
+            }
+            else
+            {
+                // TODO: throw if no setup?
+            }
+
+            return target;
+        }
+
+        /// <summary>
+        /// Specifies that the current fluent invocation is expected to be 
+        /// called exactly the given <paramref name="callCount"/> number of times.
+        /// </summary>
+        public static TResult Exactly<TResult>(this TResult target, int callCount)
+        {
+            var setup = MockContext.CurrentSetup;
+            if (setup != null)
+            {
+                setup.Occurrence = Times.Exactly(callCount);
+                var mock = setup.Invocation.Target.AsMock();
+                if (Verify.IsVerifying(mock))
+                {
+                    if (mock.Invocations.Where(call => setup.AppliesTo(call)).Count() != callCount)
+                        throw new VerifyException(mock, setup);
+                }
+            }
+            else
+            {
+                // TODO: throw if no setup?
+            }
+
+            return target;
+        }
+    }
+}

--- a/src/Moq/Moq/RecursiveMockBehavior.cs
+++ b/src/Moq/Moq/RecursiveMockBehavior.cs
@@ -46,11 +46,12 @@ namespace Moq.Sdk
                         new Type[0], 
                         new object[0])).Mock;
 
-                    // Clone the current mock's behaviors, except for the setups and the tracking 
-                    // behavior which is added already by default.
+                    // Clone the current mock's behaviors, except for the setups and the 
+                    // context and recording behaviors which are added already by default.
                     foreach (var behavior in currentMock.Behaviors.Where(x => 
                         !(x is IMockBehaviorPipeline) && 
-                        !(x is MockTrackingBehavior)))
+                        !(x is MockContextBehavior) &&
+                        !(x is MockRecordingBehavior)))
                     {
                         recursiveMock.Behaviors.Add(behavior);
                     }

--- a/src/Moq/Moq/Syntax.cs
+++ b/src/Moq/Moq/Syntax.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Moq.Sdk;
 
 namespace Moq
 {
@@ -11,6 +10,12 @@ namespace Moq
     /// </summary>
     public static class Syntax
     {
+        /// <summary>
+        /// Verifies all occurrence constraints on the given mock' setups, and 
+        /// allows further verification on the returned instance.
+        /// </summary>
+        public static T Verify<T>(T mock) => Moq.Verify.Called(mock);
+
         /// <summary>
         /// Matches any value of the given type.
         /// </summary>

--- a/src/Moq/Moq/Verify.cs
+++ b/src/Moq/Moq/Verify.cs
@@ -1,0 +1,259 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Moq.Sdk;
+using Stunts;
+
+namespace Moq
+{
+    /// <summary>
+    /// Verifies calls to mocks.
+    /// </summary>
+    public static class Verify
+    {
+        /// <summary>
+        /// Gets whether the given mock is being verified.
+        /// </summary>
+        internal static bool IsVerifying(IMock mock)
+            => mock.State.TryGetValue<bool>(typeof(Verify), out var verifying) && verifying;
+
+        /// <summary>
+        /// Verifies all setups that had an occurrence constraint applied, 
+        /// and allows specific verifications to be performed on the returned 
+        /// object too.
+        /// </summary>
+        /// <returns>An object that can be used to perform additional call verifications.</returns>
+        public static T Called<T>(T target) => Calls(target);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="function"/> was executed 
+        /// the specified number of <paramref name="times"/>.
+        /// </summary>
+        /// <param name="function">The method invocation to match against actual calls.</param>
+        /// <param name="times">Number of times the method should have been called.</param>
+        public static void Called<T>(Func<T> function, int times) => Called(function, (Times)times);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="function"/> was called at 
+        /// least once.
+        /// </summary>
+        /// <param name="function">The method invocation to match against actual calls.</param>
+        /// <param name="message">User message to show.</param>
+        public static void Called<T>(Func<T> function, string message) => Called(function, default, message: message);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="function"/> was executed at 
+        /// least once. If <paramref name="times"/> is provided, the number of calls is verified too.
+        /// </summary>
+        /// <param name="function">The method invocation to match against actual calls.</param>
+        /// <param name="times">Optional number of times the method should have been called. Defaults to <see cref="Times.AtLeastOnce"/>.
+        /// An integer value can also be specificed since there is built-in conversion support from integer to <see cref="Times"/>.</param>
+        /// <param name="message">Optional user message to show.</param>
+        public static void Called<T>(Func<T> function, Times times = default, string message = null)
+        {
+            using (new SetupScope())
+            {
+                function();
+                var setup = MockContext.CurrentSetup;
+                var mock = MockContext.CurrentInvocation.Target.AsMock();
+                var calls = mock.Invocations.Where(x => setup.AppliesTo(x));
+                if (!times.Validate(calls.Count()))
+                    throw new VerifyException(mock, setup, message);
+            }
+        }
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="action"/> was executed the 
+        /// given number of times.
+        /// </summary>
+        /// <param name="action">The method invocation to match against actual calls.</param>
+        /// <param name="times">Number of times the method should have been called.</param>
+        public static void Called(Action action, int times) => Called(action, (Times)times);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="action"/> was executed at 
+        /// least once.
+        /// </summary>
+        /// <param name="action">The method invocation to match against actual calls.</param>
+        /// <param name="message">Optional user message to show.</param>
+        public static void Called(Action action, string message) => Called(action, default, message: message);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="action"/> was executed at 
+        /// least once. If <paramref name="times"/> is provided, the number of calls is verified too.
+        /// </summary>
+        /// <param name="action">The method invocation to match against actual calls.</param>
+        /// <param name="times">Optional number of times the method should have been called. Defaults to <see cref="Times.AtLeastOnce"/>. 
+        /// An integer value can also be specificed since there is built-in conversion support from integer to <see cref="Times"/>.</param>
+        /// <param name="message">Optional user message to show.</param>
+        public static void Called(Action action, Times times = default, string message = null)
+        {
+            using (new SetupScope())
+            {
+                action();
+                var setup = MockContext.CurrentSetup;
+                var mock = MockContext.CurrentInvocation.Target.AsMock();
+                var calls = mock.Invocations.Where(x => setup.AppliesTo(x));
+                if (!times.Validate(calls.Count()))
+                    throw new VerifyException(mock, setup, message);
+            }
+        }
+
+        /// <summary>
+        /// Verifies all setups that had an occurrence constraint applied, 
+        /// and allows specific verifications to be performed on the returned 
+        /// object too.
+        /// </summary>
+        /// <returns>An object that can be used to perform additional call verifications.</returns>
+        public static T NotCalled<T>(T target) => GetVerifier(GetVerified(target), true);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="function"/> was never called.
+        /// </summary>
+        /// <param name="function">The method invocation to match against actual calls.</param>
+        /// <param name="message">Optional user message to show.</param>
+        public static void NotCalled<T>(Func<T> function, string message = null) => Called(function, Times.Never, message);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="action"/> was never called.
+        /// </summary>
+        /// <param name="action">The method invocation to match against actual calls.</param>
+        /// <param name="message">Optional user message to show.</param>
+        public static void NotCalled(Action action, string message = null) => Called(action, Times.Never, message);
+
+        /// <summary>
+        /// Verifies all setups that had an occurrence constraint applied, 
+        /// and allows specific verifications to be performed on the returned 
+        /// object too.
+        /// </summary>
+        /// <returns>An object that can be used to perform additional call verifications.</returns>
+        public static T Calls<T>(T target) => GetVerifier(GetVerified(target));
+
+        /// <summary>
+        /// Allows performing custom verification against all actual calls that match the 
+        /// method invocation in <paramref name="function"/>.
+        /// </summary>
+        /// <param name="function">The method invocation to match against actual calls.</param>
+        /// <param name="calls">Actual calls that match the given <paramref name="function"/>.</param>
+        public static void Calls(Func<object> function, Action<IEnumerable<IMethodInvocation>> calls)
+        {
+            using (new SetupScope())
+            {
+                function();
+                var setup = MockContext.CurrentSetup;
+                var mock = MockContext.CurrentInvocation.Target.AsMock();
+                calls.Invoke(mock.Invocations.Where(x => setup.AppliesTo(x)));
+            }
+        }
+
+        /// <summary>
+        /// Allows performing custom verification against all actual calls that match the 
+        /// method invocation in <paramref name="action"/>.
+        /// </summary>
+        /// <param name="action">The method invocation to match against actual calls.</param>
+        /// <param name="calls">Actual calls that match the given <paramref name="action"/>.</param>
+        public static void Calls(Action action, Action<IEnumerable<IMethodInvocation>> calls)
+        {
+            using (new SetupScope())
+            {
+                action();
+                var setup = MockContext.CurrentSetup;
+                var mock = MockContext.CurrentInvocation.Target.AsMock();
+                calls.Invoke(mock.Invocations.Where(x => setup.AppliesTo(x)));
+            }
+        }
+
+        /// <summary>
+        /// Gets the mock after verifying that all setups that specified occurrence 
+        /// constraints have succeeded.
+        /// </summary>
+        static IMock<T> GetVerified<T>(T target)
+        {
+            var mock = target.AsMock();
+            var failures = (from pipeline in mock.Setups
+                            where pipeline.Setup.Occurrence != null
+                            let times = pipeline.Setup.Occurrence.Value
+                            let calls = mock.Invocations.Where(x => pipeline.AppliesTo(x)).ToArray()
+                            where !times.Validate(calls.Length)
+                            select pipeline.Setup
+                           ).ToArray();
+
+            if (failures.Length > 0)
+                throw new VerifyException(mock, failures);
+
+            return mock;
+        }
+
+        /// <summary>
+        /// Gets a clone of the original mock for verification purposes.
+        /// </summary>
+        /// <param name="mock">The mock to be cloned.</param>
+        /// <param name="notCalled">Whether to add a behavior that verifies the invocations performed on 
+        /// the clone were never performed on the original mock.
+        /// </param>
+        static T GetVerifier<T>(IMock<T> mock, bool notCalled = false)
+        {
+            // If the mock is already being verified, we don't need to clone again.
+            if (mock.State.TryGetValue<bool>(typeof(Verify), out var verifying) && verifying)
+                return mock.Object;
+
+            // Otherwise, we create a verification copy that does not record invocations 
+            // and has default behavior.
+            var clone = mock.Clone();
+
+            var recording = clone.Behaviors.OfType<MockRecordingBehavior>().FirstOrDefault();
+            if (recording != null)
+                clone.Behaviors.Remove(recording);
+
+            // The target replacer is needed so that whenever we try to get the target object 
+            // and the IMock from it for occurrence verification, we actually get to the actual 
+            // target being verified, not the cloned mock. Otherwise, invocations won't match 
+            // with the setups, since the target would be different.
+            clone.Behaviors.Insert(
+                clone.Behaviors.IndexOf(clone.Behaviors.OfType<MockContextBehavior>().First()) + 1,
+                new TargetReplacerBehavior(mock.Object));
+
+            if (notCalled)
+            {
+                clone.Behaviors.Insert(
+                    clone.Behaviors.IndexOf(clone.Behaviors.OfType<TargetReplacerBehavior>().First()) + 1,
+                    new NotCalledBehavior());
+            }
+
+            // Sets up the right behaviors for a loose mock
+            new Moq<T>(clone).Behavior = MockBehavior.Loose;
+
+            clone.State.Set(typeof(Verify), true);
+
+            return clone.Object;
+        }
+
+        class NotCalledBehavior : IStuntBehavior
+        {
+            public bool AppliesTo(IMethodInvocation invocation) => true;
+
+            public IMethodReturn Execute(IMethodInvocation invocation, GetNextBehavior next)
+            {
+                var mock = invocation.Target.AsMock();
+                var setup = MockContext.CurrentSetup;
+                if (mock.Invocations.Where(x => setup.AppliesTo(x)).Any())
+                    throw new VerifyException(mock, setup);
+
+                return next().Invoke(invocation, next);
+            }
+        }
+
+        class TargetReplacerBehavior : IStuntBehavior
+        {
+            readonly object target;
+
+            public TargetReplacerBehavior(object target) => this.target = target;
+
+            public bool AppliesTo(IMethodInvocation invocation) => true;
+
+            public IMethodReturn Execute(IMethodInvocation invocation, GetNextBehavior next) => next().Invoke(invocation, next);
+            //public IMethodReturn Execute(IMethodInvocation invocation, GetNextBehavior next)
+            //    => next().Invoke(new MethodInvocation(target, invocation.MethodBase, invocation.Arguments.ToArray()), next);
+        }
+    }
+}

--- a/src/Moq/Moq/VerifyException.cs
+++ b/src/Moq/Moq/VerifyException.cs
@@ -1,57 +1,42 @@
-﻿using System;
-using Moq.Sdk;
+﻿using Moq.Sdk;
 
 namespace Moq
 {
     /// <summary>
     /// A verification failed to match a mock's invocations 
-    /// against a given <see cref="Setup"/> setup.
+    /// against the given <see cref="Setups"/> setup(s).
     /// </summary>
     public class VerifyException : MockException
     {
         /// <summary>
         /// Initializes the exception with the target 
-        /// mock and setup that failed to match invocations.
+        /// mock and setup(s) that failed to match invocations.
         /// </summary>
-        public VerifyException(IMock mock, IMockSetup setup)
-            : base(setup.ToString())
+        public VerifyException(IMock mock, IMockSetup setup, string message = null)
+            : this(mock, new[] { setup }, message)
         {
-            Mock = mock;
-            Setup = setup;
         }
 
-        /// <summary>
-        /// The expected setup that should have matched the 
-        /// invocations on the mock.
-        /// </summary>
-        public IMockSetup Setup { get; }
-
-        /// <summary>
-        /// The mock that was tested against the given setup.
-        /// </summary>
-        public IMock Mock { get; }
-    }
-
-    /// <summary>
-    /// A verification failed to match a mock's invocations 
-    /// against a given expected <see cref="IMockSetup"/> setup.
-    /// </summary>
-    /// <typeparam name="T">The type of the mocked instance.</typeparam>
-    public class VerifyException<T> : VerifyException
-    {
         /// <summary>
         /// Initializes the exception with the target 
-        /// mock and setup that failed to match invocations.
+        /// mock and setup(s) that failed to match invocations.
         /// </summary>
-        public VerifyException(IMock<T> mock, IMockSetup setup)
-            : base(mock, setup)
+        public VerifyException(IMock mock, IMockSetup[] setups, string message = null)
+            : base(message)
         {
             Mock = mock;
+            Setups = setups;
         }
 
         /// <summary>
-        /// The mock that was tested against the given setup.
+        /// The expected setups that should have matched the invocations on the mock 
+        /// but didn't.
         /// </summary>
-        public new IMock<T> Mock { get; }
+        public IMockSetup[] Setups { get; }
+
+        /// <summary>
+        /// The mock that was tested.
+        /// </summary>
+        public IMock Mock { get; }
     }
 }

--- a/src/Moq/Moq/VerifyExtension.cs
+++ b/src/Moq/Moq/VerifyExtension.cs
@@ -1,46 +1,77 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Linq;
 using Moq.Sdk;
 
 namespace Moq
 {
     /// <summary>
-    /// Provides mock verification methods.
+    /// Provides mock instance verification extension methods.
     /// </summary>
     [EditorBrowsable(EditorBrowsableState.Never)]
     public static class VerifyExtension
     {
         /// <summary>
-        /// Verifies the mock received at least one invocation that matches 
-        /// the given lambda.
+        /// Verifies a method invocation matching the <paramref name="action"/> was executed the 
+        /// given number of times.
         /// </summary>
-        public static void Verify<T>(this T mock, Action<T> action)
-        {
-            using (new SetupScope())
-            {
-                action(mock);
-                var setup = MockContext.CurrentSetup;
-                var info = mock.AsMock();
-                if (!info.Invocations.Any(i => setup.AppliesTo(i)))
-                    throw new VerifyException<T>(info, setup);
-            }
-        }
+        /// <param name="target">The mock instance to verify.</param>
+        /// <param name="action">The method invocation to match against actual calls.</param>
+        /// <param name="times">Number of times the method should have been called.</param>
+        public static void Verify<T>(this T target, Action<T> action, int times)
+            => Moq.Verify.Called(() => action(target), times);
 
         /// <summary>
-        /// Verifies the mock received at least one invocation that matches 
-        /// the given lambda.
+        /// Verifies a method invocation matching the <paramref name="action"/> was executed at 
+        /// least once.
         /// </summary>
-        public static void Verify<T, TResult>(this T mock, Func<T, TResult> function)
-        {
-            using (new SetupScope())
-            {
-                function(mock);
-                var setup = MockContext.CurrentSetup;
-                var info = mock.AsMock();
-                if (!info.Invocations.Any(i => setup.AppliesTo(i)))
-                    throw new VerifyException<T>(info, setup);
-            }
-        }
+        /// <param name="target">The mock instance to verify.</param>
+        /// <param name="action">The method invocation to match against actual calls.</param>
+        /// <param name="message">Optional user message to show.</param>
+        public static void Verify<T>(this T target, Action<T> action, string message)
+            => Moq.Verify.Called(() => action(target), message);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="action"/> was executed at 
+        /// least once. If <paramref name="times"/> is provided, the number of calls is verified too.
+        /// </summary>
+        /// <param name="target">The mock instance to verify.</param>
+        /// <param name="action">The method invocation to match against actual calls.</param>
+        /// <param name="times">Optional number of times the method should have been called. Defaults to <see cref="Times.AtLeastOnce"/>. 
+        /// An integer value can also be specificed since there is built-in conversion support from integer to <see cref="Times"/>.</param>
+        /// <param name="message">Optional user message to show.</param>
+        public static void Verify<T>(this T target, Action<T> action, Times times = default, string message = null)
+            => Moq.Verify.Called(() => action(target), times, message);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="function"/> was executed the 
+        /// given number of times.
+        /// </summary>
+        /// <param name="target">The mock instance to verify.</param>
+        /// <param name="function">The method invocation to match against actual calls.</param>
+        /// <param name="times">Number of times the method should have been called.</param>
+        public static void Verify<T, TResult>(this T target, Func<T, TResult> function, int times)
+            => Moq.Verify.Called(() => function(target), times);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="function"/> was executed at 
+        /// least once.
+        /// </summary>
+        /// <param name="target">The mock instance to verify.</param>
+        /// <param name="function">The method invocation to match against actual calls.</param>
+        /// <param name="message">Optional user message to show.</param>
+        public static void Verify<T, TResult>(this T target, Func<T, TResult> function, string message)
+            => Moq.Verify.Called(() => function(target), message);
+
+        /// <summary>
+        /// Verifies a method invocation matching the <paramref name="function"/> was executed at 
+        /// least once. If <paramref name="times"/> is provided, the number of calls is verified too.
+        /// </summary>
+        /// <param name="target">The mock instance to verify.</param>
+        /// <param name="function">The method invocation to match against actual calls.</param>
+        /// <param name="times">Optional number of times the method should have been called. Defaults to <see cref="Times.AtLeastOnce"/>. 
+        /// An integer value can also be specificed since there is built-in conversion support from integer to <see cref="Times"/>.</param>
+        /// <param name="message">Optional user message to show.</param>
+        public static void Verify<T, TResult>(this T target, Func<T, TResult> function, int times = -1, string message = null)
+            => Moq.Verify.Called(() => function(target), times, message);
     }
 }

--- a/src/Stunts/Stunts.Tests/InternalTests.cs
+++ b/src/Stunts/Stunts.Tests/InternalTests.cs
@@ -121,9 +121,13 @@ $@"<Project Sdk='Microsoft.NET.Sdk'>
             var resource = repo.GetResourceAsync<PackageMetadataResource>().Result;
             var metadata = resource.GetMetadataAsync("Microsoft.CodeAnalysis.Workspaces.Common", true, false, new Logger(null), CancellationToken.None).Result;
 
+            // 3.1.0 is already stable and we verified we work with it
+            // Older versions are guaranteed to not change either, so we 
+            // can rely on it working too, since this test passed at some 
+            // point too.
             return metadata
                 .Select(m => m.Identity)
-                .Where(m => m.Version >= new NuGetVersion("2.9.0"))
+                .Where(m => m.Version >= new NuGetVersion("3.1.0"))
                 .Select(v => new object[] { v });
         }
 

--- a/src/Stunts/Stunts/IMethodInvocation.cs
+++ b/src/Stunts/Stunts/IMethodInvocation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 

--- a/src/Stunts/Stunts/MethodInvocation.cs
+++ b/src/Stunts/Stunts/MethodInvocation.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
 using System.Linq;
-using System.Collections;
 using System.Runtime.CompilerServices;
 using TypeNameFormatter;
 using System.Diagnostics;

--- a/src/build/Version.targets
+++ b/src/build/Version.targets
@@ -29,9 +29,13 @@ AssemblyVersion=$(AssemblyVersion)" />
           Returns="$(Version)"
           Condition="'$(GitInfoImported)' == 'true' And '$(ExcludeRestorePackageImports)' != 'true'">
 
+    <PropertyGroup>
+      <GitBranch Condition="$(CI)">$(GitBranch.Replace('/', '_'))</GitBranch>
+    </PropertyGroup>
+
     <ItemGroup>
       <LabelMetadata Include="$(GitSemVerLabel)" Condition="'$(GitSemVerLabel)' != ''" />
-      <LabelMetadata Include="$(GitBranch)" Condition="'$(GitBranch)' != 'master' and '$(GitSemVerSource)' != 'Branch' and '$(GitSemVerLabel)' != '$(GitBranch)'" />
+      <LabelMetadata Include="$(GitBranch)" Condition="$(CI) and '$(GitBranch)' != 'master' and '$(GitSemVerSource)' != 'Branch' and '$(GitSemVerLabel)' != '$(GitBranch)'" />
       <LabelMetadata Include="pr$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)" Condition="'$(SYSTEM_PULLREQUEST_PULLREQUESTNUMBER)' != ''" />
 
       <VersionMetadata Include="$(GitCommits)" Condition="'$(GitSemVerLabel)' == '' and '$(GitCommits)' != '0'" />


### PR DESCRIPTION
Just like for Arg, Raise and Setup, there is now a Syntax-based Verify which
allows much more succinct code. With the following using at the top:

```
using static Moq.Syntax;
```

You can now perform verifications on a mock as follows:

```
// Verify all "verifiable" calls, i.e. those with a Once/Never/etc. setup.
Verify(calculator);

// Verify a specific invocation was made at least once
Verify(calculator).Add(2, 3);

// Verify it was never called
Verify(calculator).Add(1, 1).Never();

// Verify it was called exactly once
Verify(calculator).Add(1, 1).Once();
```

Verifiable setups can now just add `Once`, `Never` and `Exactly` directly on
the setup too (unlike v4 which only had `Verifiable()` which meant `AtLeastOnce`)

```
var calculator = Mock.Of<Calculator>();

// The given call is expected only once
calculator.Add(2, 3).Returns(5).Once();

// The given call is never expected
calculator.Add(-1, -1).Never();

// The given call is expected at least once. Equivalent to v4 Verifiable
calculator.Add(1, 1).AtLeastOnce();

// A single call to Verify will verify all the above
Verify(calculator);

// Also supported, non-syntax version
Verify.Called(calculator);
// And instance version (via extension method backwards compatible)
calculator.Verify();
```

A non-syntax version is also provided, which is basically called from the
syntax one:

```
// Verify all "verifiable" calls, i.e. those with a Once/Never/etc. setup.
Verify.Called(calculator);

// Verify a specific invocation was made at least once
Verify.Called(calculator).Add(2, 3);

// Verify it was never called
Verify.Called(calculator).Add(1, 1).Never();

// Or alternative syntax depending on style preference
Verify.NotCalled(calculator).Add(2, 3);
```

A mechanism in the SDK for cloning mocks was added, so that they can be
"frozen" and tweaked independently from the original mock (i.e. for verification
purposes).

As part of cleaning up a mock's behaviors for cloning and verification, we took
the chance to split the former `MockTrackingBehavior` (which was doing two things)
into `MockContextBehavior` (the one that sets the `MockContext` static properties)
and `MockRecordingBehavior` (which does the actual invocation recording). This
allows getting a cloned mock that does not record calls, for example, for verifying
purposes or diagnostics, say. This could be used to also clone on debugger inspection,
to allow preserving the actual calls instead of having the inspection to modify the
actual calls (which is what happens typically by default in all mocking libraries).