### PR TITLE
Add codefix for setup of ref/out methods

### DIFF
--- a/Moq.sln
+++ b/Moq.sln
@@ -39,7 +39,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{
 		.github\workflows\release.yml = .github\workflows\release.yml
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moq.CodeAnalysis.UnitTests", "src\Moq.CodeAnalysis.UnitTests\Moq.CodeAnalysis.UnitTests.csproj", "{7EFC63B5-6978-40C9-8FEF-4FEEB4019B4C}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moq.CodeAnalysis.UnitTests", "src\Moq.CodeAnalysis.UnitTests\Moq.CodeAnalysis.UnitTests.csproj", "{7EFC63B5-6978-40C9-8FEF-4FEEB4019B4C}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Moq.Vsix", "src\Moq.Vsix\Moq.Vsix.csproj", "{EB67F50E-322F-4B22-9B30-EC80AE7CBE88}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -87,6 +89,10 @@ Global
 		{7EFC63B5-6978-40C9-8FEF-4FEEB4019B4C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EFC63B5-6978-40C9-8FEF-4FEEB4019B4C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EFC63B5-6978-40C9-8FEF-4FEEB4019B4C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EB67F50E-322F-4B22-9B30-EC80AE7CBE88}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EB67F50E-322F-4B22-9B30-EC80AE7CBE88}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EB67F50E-322F-4B22-9B30-EC80AE7CBE88}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EB67F50E-322F-4B22-9B30-EC80AE7CBE88}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,6 +32,7 @@
     <RestoreSources>https://pkg.kzu.io/index.json;https://api.nuget.org/v3/index.json;$(RestoreSources)</RestoreSources>
     <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)..\..\nugetizer\bin\')">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\nugetizer\bin'));$(RestoreSources)</RestoreSources>
     <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)..\..\stunts\bin\')">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\stunts\bin'));$(RestoreSources)</RestoreSources>
+    <RestoreSources Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')">$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin'));$(RestoreSources)</RestoreSources>
 
     <AssemblyOriginatorKeyFile>$(MSBuildThisFileDirectory)Moq.snk</AssemblyOriginatorKeyFile>
     <PublicKey>002400000480000094000000060200000024000052534131000400000100010051155fd0ee280be78d81cc979423f1129ec5dd28edce9cd94fd679890639cad54c121ebdb606f8659659cd313d3b3db7fa41e2271158dd602bb0039a142717117fa1f63d93a2d288a1c2f920ec05c4858d344a45d48ebd31c1368ab783596b382b611d8c92f9c1b3d338296aa21b12f3bc9f34de87756100c172c52a24bad2db</PublicKey>

--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -8,7 +8,8 @@
   <ItemGroup Label="Core">
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.0.0" />
     <PackageVersion Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0" />
-    <PackageVersion Include="ThisAssembly" Version="1.0.0-rc" />
+    <PackageVersion Include="ThisAssembly" Version="1.0.0-rc.1" />
+    <PackageVersion Update="ThisAssembly" Version="42.42.42" Condition="Exists('$(MSBuildThisFileDirectory)..\..\ThisAssembly\bin\')" />
     <PackageVersion Include="NuGetizer" Version="0.4.9" />
     <PackageVersion Update="NuGetizer" Version="42.42.42" Condition="Exists('$(MSBuildThisFileDirectory)..\..\nugetizer\bin\')" />
     <PackageVersion Include="Stunts" Version="$(StuntsVersion)" />
@@ -65,6 +66,8 @@
     <PackageVersion Include="Castle.Core" Version="4.4.1" />
     <PackageVersion Include="Superpower" Version="2.3.0" />
     <PackageVersion Include="Ben.Demystifier" Version="0.1.4" />
+
+    <PackageVersion Include="Microsoft.VSSDK.BuildTools" Version="16.7.3069" />
   </ItemGroup>
 
 </Project>

--- a/src/Moq.CodeAnalysis/CustomDelegateCompletion.cs
+++ b/src/Moq.CodeAnalysis/CustomDelegateCompletion.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Immutable;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Completion;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Options;
+using Microsoft.CodeAnalysis.Tags;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Moq.CodeAnalysis
+{
+    [ExportCompletionProvider(nameof(CustomDelegateCompletion), LanguageNames.CSharp)]
+    public class CustomDelegateCompletion : CompletionProvider
+    {
+        static readonly CompletionItemRules rules = CompletionItemRules.Create(selectionBehavior: CompletionItemSelectionBehavior.SoftSelection);
+
+        public override Task<CompletionDescription> GetDescriptionAsync(Document document, CompletionItem item, CancellationToken cancellationToken)
+        {
+            if (!item.Tags.Contains(nameof(CustomDelegateCompletion)))
+                return base.GetDescriptionAsync(document, item, cancellationToken);
+
+            return Task.FromResult(CompletionDescription.FromText(ThisAssembly.Strings.CustomDelegateCompletion.Description));
+        }
+
+        public override Task<CompletionChange> GetChangeAsync(Document document, CompletionItem item, char? commitKey, CancellationToken cancellationToken)
+        {
+            File.AppendAllText(Path.Combine(Path.GetTempPath(), nameof(CustomDelegateCompletion) + ".txt"), nameof(GetChangeAsync));
+            return base.GetChangeAsync(document, item, commitKey, cancellationToken);
+        }
+
+        public override async Task ProvideCompletionsAsync(CompletionContext context)
+        {
+            if (context.Document.SupportsSemanticModel != true)
+                return;
+
+            var position = context.Position;
+            var document = context.Document;
+            var cancellation = context.CancellationToken;
+
+            var root = await document.GetSyntaxRootAsync(cancellation).ConfigureAwait(false);
+            if (root == null)
+                return;
+
+            var span = context.CompletionListSpan;
+            var token = root.FindToken(span.Start);
+            if (token.Parent == null)
+                return;
+
+            var node = token.Parent.AncestorsAndSelf().FirstOrDefault(a => a.FullSpan.Contains(span));
+            if (node == null)
+                return;
+
+            if (node.AncestorsAndSelf().OfType<InvocationExpressionSyntax>().FirstOrDefault() is not InvocationExpressionSyntax invocation)
+                return;
+
+            var semantic = await document.GetSemanticModelAsync(cancellation).ConfigureAwait(false);
+            if (semantic == null)
+                return;
+
+            var scope = semantic.Compilation.GetTypeByMetadataName(typeof(SetupScopeAttribute).FullName);
+            if (scope == null)
+                return;
+
+            bool IsSetupScope(ISymbol? symbol) => symbol is IMethodSymbol &&
+                symbol.GetAttributes().Any(a => SymbolEqualityComparer.Default.Equals(a.AttributeClass, scope));
+
+            if (!IsSetupScope(semantic.GetSymbolInfo(invocation, cancellation).Symbol) && 
+                !semantic.GetSymbolInfo(invocation, cancellation).CandidateSymbols.Any(IsSetupScope))
+                return;
+
+            if (invocation.Expression is not MemberAccessExpressionSyntax member)
+                return;
+
+            var symbol = semantic.GetSymbolInfo(member.Expression, cancellation).Symbol;
+            var target = symbol as ITypeSymbol ?? (symbol as ILocalSymbol)?.Type;
+
+            if (symbol == null || target == null)
+                return;
+
+            var start = invocation.ArgumentList.Span.Start + 1;
+            var length = span.End - start;
+            // Wrong length, shouldn't happen, but bail just in case.
+            if (length < 0)
+                return;
+
+            var existing = (await document.GetTextAsync(cancellation).ConfigureAwait(false))
+                .GetSubText(new TextSpan(start, length)).ToString();
+
+            // In this case, completion would already have the right items, no need to annotate.
+            if (existing.StartsWith(symbol.Name + "."))
+                return;
+
+            // List all the members of the target type that have ref/out parameter
+            var members = target.GetMembers().OfType<IMethodSymbol>()
+                .Where(m => m.Parameters.Any(p => p.RefKind == RefKind.Ref || p.RefKind == RefKind.Out)).ToArray();
+
+            foreach (var candidate in members)
+            {
+                context.AddItem(CompletionItem.Create(
+                    displayText: symbol.Name + "." + candidate.Name,
+                    sortText: symbol.Name + "." + candidate.Name,
+                    filterText: symbol.Name + "." + candidate.Name,
+                    tags: ImmutableArray.Create(WellKnownTags.Method).Add(nameof(CustomDelegateCompletion)),
+                    rules: rules,
+                    inlineDescription: "Setup via delegate"));
+            }
+        }
+
+        public override bool ShouldTriggerCompletion(SourceText text, int caretPosition, CompletionTrigger trigger, OptionSet options)
+        {
+            if (trigger.Kind == CompletionTriggerKind.Invoke ||
+                trigger.Kind == CompletionTriggerKind.InvokeAndCommitIfUnique)
+                return true;
+
+            if (trigger.Kind == CompletionTriggerKind.Insertion && 
+                (trigger.Character == '.' || trigger.Character == '('))
+                return true;
+
+            return base.ShouldTriggerCompletion(text, caretPosition, trigger, options);
+        }
+    }
+}

--- a/src/Moq.CodeAnalysis/Moq.CodeAnalysis.csproj
+++ b/src/Moq.CodeAnalysis/Moq.CodeAnalysis.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Superpower" PrivateAssets="all" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Pack="false" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Pack="false" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Features" Pack="false" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic" Pack="false" />
     <PackageReference Include="Microsoft.CodeAnalysis.VisualBasic.Workspaces" Pack="false" />
 
@@ -21,7 +22,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\Moq.Sdk\Moq.Sdk.csproj" />
+    <ProjectReference Include="..\Moq.Sdk\Moq.Sdk.csproj" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Moq.CodeAnalysis/Resources.Designer.cs
+++ b/src/Moq.CodeAnalysis/Resources.Designer.cs
@@ -70,6 +70,16 @@ namespace Moq.CodeAnalysis {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to A subsequent code fix for this completion will allow you to generate a 
+        ///delegate to set up this method directly with the right Returns signature..
+        /// </summary>
+        internal static string CustomDelegateCompletion_Description {
+            get {
+                return ResourceManager.GetString("CustomDelegateCompletion_Description", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Project &apos;{0}&apos; does not reference the required Moq assembly..
         /// </summary>
         internal static string MoqRequired {

--- a/src/Moq.CodeAnalysis/Resources.resx
+++ b/src/Moq.CodeAnalysis/Resources.resx
@@ -120,6 +120,11 @@
   <data name="CustomDelegateCodeFix_TitleFormat" xml:space="preserve">
     <value>Setup mock with typed delegate for {0}</value>
   </data>
+  <data name="CustomDelegateCompletion_Description" xml:space="preserve">
+    <value>A subsequent code fix for this completion will allow you to generate a 
+delegate to set up this method directly with the right Returns signature.</value>
+    <comment>Description for completion</comment>
+  </data>
   <data name="MoqRequired" xml:space="preserve">
     <value>Project '{0}' does not reference the required Moq assembly.</value>
   </data>

--- a/src/Moq.Sdk/SetupScopeAttribute.cs
+++ b/src/Moq.Sdk/SetupScopeAttribute.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Moq
+{
+    /// <summary>
+    /// Annotates a method that creates an implicit <see cref="SetupScope"/>.
+    /// </summary>
+    /// <remarks>
+    /// This allows a method like <c>Setup</c> that receives a lambda, to have 
+    /// its parameter considered as a setup lambda, so that executing it does 
+    /// not cause the actual mock behavior to run, and instead it turns on 
+    /// an automatic <see cref="SetupScope"/> so that behaviors can adapt to 
+    /// the invocation dynamically.
+    /// </remarks>
+    [AttributeUsage(AttributeTargets.Method)]
+    public class SetupScopeAttribute : Attribute
+    {
+    }
+}

--- a/src/Moq.Vsix/Moq.Vsix.csproj
+++ b/src/Moq.Vsix/Moq.Vsix.csproj
@@ -1,0 +1,55 @@
+﻿<Project>
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.props" />
+
+  <PropertyGroup>
+    <TargetFramework>net472</TargetFramework>
+    <RootNamespace>Moq.Vsix</RootNamespace>
+    <AssemblyName>Moq.Vsix</AssemblyName>
+  </PropertyGroup>
+
+  <PropertyGroup>
+    <GeneratePkgDefFile>false</GeneratePkgDefFile>
+    <IncludeAssemblyInVSIXContainer>false</IncludeAssemblyInVSIXContainer>
+    <IncludeDebugSymbolsInVSIXContainer>true</IncludeDebugSymbolsInVSIXContainer>
+    <IncludeDebugSymbolsInLocalVSIXDeployment>true</IncludeDebugSymbolsInLocalVSIXDeployment>
+    <CopyBuildOutputToOutputDirectory>false</CopyBuildOutputToOutputDirectory>
+    <CopyOutputSymbolsToOutputDirectory>false</CopyOutputSymbolsToOutputDirectory>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.VSSDK.BuildTools" Condition="'$(MSBuildRuntimeType)' == 'Full'" />
+    <PackageReference Include="Stunts" />
+    <PackageReference Include="Stunts.CodeAnalysis" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <StartAction>Program</StartAction>
+    <StartProgram>$(DevEnvDir)devenv.exe</StartProgram>
+    <StartArguments>/rootsuffix Exp</StartArguments>
+  </PropertyGroup>
+  
+  <Import Sdk="Microsoft.NET.Sdk" Project="Sdk.targets" />
+  <Import Project="$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets" Condition="Exists('$(VSToolsPath)\VSSDK\Microsoft.VsSDK.targets')" />
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Moq.CodeAnalysis\Moq.CodeAnalysis.csproj" />
+    <ProjectReference Include="..\Moq.Sdk\Moq.Sdk.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- https://github.com/dotnet/sdk/issues/433 -->
+    <ProjectReference Update="@(ProjectReference)" AdditionalProperties="TargetFramework=netstandard2.0" />
+
+    <!-- https://github.com/Microsoft/extendvs/issues/57 -->
+    <ProjectReference Update="@(ProjectReference)" Name="%(Filename)" />
+  </ItemGroup>
+
+  <Target Name="AddPrivateAssets" BeforeTargets="GetVsixSourceItems">
+    <ItemGroup>
+      <VSIXSourceItem Include="@(RuntimeCopyLocalItems)"
+                      Condition="'%(NuGetPackageId)' == 'Stunts' or 
+                                 '%(NuGetPackageId)' == 'Stunts.CodeAnalysis'"/>
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/src/Moq.Vsix/source.extension.vsixmanifest
+++ b/src/Moq.Vsix/source.extension.vsixmanifest
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PackageManifest Version="2.0.0" xmlns="http://schemas.microsoft.com/developer/vsx-schema/2011" xmlns:d="http://schemas.microsoft.com/developer/vsx-schema-design/2011">
+  <Metadata>
+    <Identity Id="Moq.Vsix" Version="1.0" Language="en-US" Publisher="danie"/>
+    <DisplayName>Moq Completion Tester</DisplayName>
+    <Description xml:space="preserve">This is only needed to make troubleshooting and debuging custom completions more convenient.</Description>
+  </Metadata>
+  <Installation>
+    <InstallationTarget Id="Microsoft.VisualStudio.Community" Version="[16.0,)" />
+  </Installation>
+  <Assets>
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Moq.CodeAnalysis" Path="|Moq.CodeAnalysis|"/>
+    <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="Moq.CodeAnalysis" Path="|Moq.CodeAnalysis|"/>
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="Project" d:ProjectName="Moq.Sdk" Path="|Moq.Sdk|"/>
+    <Asset Type="Microsoft.VisualStudio.Analyzer" d:Source="Project" d:ProjectName="Moq.Sdk" Path="|Moq.Sdk|"/>
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Stunts"/>
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Stunts.CodeAnalysis"/>
+    <Asset Type="Microsoft.VisualStudio.MefComponent" d:Source="File" Path="Superpower"/>
+  </Assets>
+  <Prerequisites>
+    <Prerequisite Id="Microsoft.VisualStudio.Component.CoreEditor" Version="[16.0,)" DisplayName="Visual Studio core editor" />
+    <Prerequisite Id="Microsoft.VisualStudio.Component.Roslyn.LanguageServices" Version="[16.0,)" DisplayName="Roslyn Language Services" />
+  </Prerequisites>
+</PackageManifest>

--- a/src/Moq/SetupExtension.cs
+++ b/src/Moq/SetupExtension.cs
@@ -20,11 +20,13 @@ namespace Moq
         /// is active and affects all invocations to any mocks called within the block. 
         /// </remarks>
         /// <seealso cref="SetupScope"/>
+        [SetupScope]
         public static IDisposable Setup<T>(this T mock) => new SetupScope();
 
         /// <summary>
         /// Sets up the mock with the given void method call.
         /// </summary>
+        [SetupScope]
         public static ISetup Setup<T>(this T mock, Action<T> action)
         {
             using (new SetupScope())
@@ -37,6 +39,7 @@ namespace Moq
         /// <summary>
         /// Sets up the mock with the given function.
         /// </summary>
+        [SetupScope]
         public static TResult Setup<T, TResult>(this T mock, Func<T, TResult> function)
         {
             using (new SetupScope())
@@ -50,6 +53,7 @@ namespace Moq
         /// access and set ref/out arguments. A code fix will automatically 
         /// generate a delegate with the right signature when using this overload.
         /// </summary>
+        [SetupScope]
         public static ISetup<TDelegate> Setup<TDelegate>(this object mock, TDelegate member)
             => new DefaultSetup<TDelegate>(member as Delegate ?? throw new ArgumentException(ThisAssembly.Strings.Setup.DelegateExpected));
 
@@ -61,6 +65,7 @@ namespace Moq
         /// and pass in the method group directly instead. A code fix will automatically 
         /// generate a delegate with the right signature when using this overload.
         /// </summary>
+        [SetupScope]
         public static ISetup<TDelegate> Setup<TDelegate>(this object mock, Func<TDelegate> memberFunction)
         {
             using (new SetupScope())


### PR DESCRIPTION
This is one of the most annoying scenarios when mocking APIs that have ref/out arguments. Figuring out the callback parameters, setting up the right output values in an untyped collection of some sort, it's terrible.

So rather than that, offer a built-in way to generate a delegate that can be used to directly set up and implement the method, with full typed arguments including ref/out annotations, just like you would if you implemented the interface manually (which you likely do when things get complicated because of this issue!).

When you get to the setup and specify the method you want to work with, you get a nice codefix suggestion that generates the delegate *and* the Returns call with the right parameters:

![RefOut](https://user-images.githubusercontent.com/169707/97519764-87337b00-1978-11eb-965b-e0223065e876.gif)

Setting up tests for this will be more complicated than for built-in analyzers, pending further investigation.